### PR TITLE
modify(entity, sql): 주문 엔티티 필드 추가 및 결제 매핑에서 주인 변경, 장바구니 테이블 분리

### DIFF
--- a/src/main/java/com/nhnacademy/back/cart/domain/entity/CartItems.java
+++ b/src/main/java/com/nhnacademy/back/cart/domain/entity/CartItems.java
@@ -1,13 +1,14 @@
 package com.nhnacademy.back.cart.domain.entity;
 
-import com.nhnacademy.back.account.customer.domain.entity.Customer;
+import com.nhnacademy.back.product.product.domain.entity.Product;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,14 +16,21 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Cart {
+public class CartItems {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private long cartId;
+	private long cartItemsId;
 
-	@OneToOne(optional = false)
-	@JoinColumn(name = "customer_id")
-	private Customer customer;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "cart_id")
+	private Cart cart;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "product_id")
+	private Product product;
+
+	@Column(nullable = false)
+	private int cartItemsQuantity;
 
 }

--- a/src/main/java/com/nhnacademy/back/order/order/domain/entity/Order.java
+++ b/src/main/java/com/nhnacademy/back/order/order/domain/entity/Order.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import com.nhnacademy.back.account.customer.domain.entity.Customer;
 import com.nhnacademy.back.coupon.membercoupon.domain.entity.MemberCoupon;
 import com.nhnacademy.back.order.deliveryfee.domain.entity.DeliveryFee;
-import com.nhnacademy.back.order.payment.domain.entity.Payment;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -70,9 +69,5 @@ public class Order {
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "customer_id")
 	private Customer customer;
-
-	@OneToOne(optional = false)
-	@JoinColumn(name = "payment_id")
-	private Payment payment;
 
 }

--- a/src/main/java/com/nhnacademy/back/order/payment/domain/entity/Payment.java
+++ b/src/main/java/com/nhnacademy/back/order/payment/domain/entity/Payment.java
@@ -2,6 +2,7 @@ package com.nhnacademy.back.order.payment.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.nhnacademy.back.order.order.domain.entity.Order;
 import com.nhnacademy.back.order.paymentmethod.domain.entity.PaymentMethod;
 
 import jakarta.persistence.Column;
@@ -39,4 +40,7 @@ public class Payment {
 	@JoinColumn(name = "payment_method_id")
 	private PaymentMethod paymentMethod;
 
+	@OneToOne(optional = false)
+	@JoinColumn(name = "order_code")
+	private Order order;
 }

--- a/src/main/resources/sql/data/cart.sql
+++ b/src/main/resources/sql/data/cart.sql
@@ -1,6 +1,12 @@
 -- 이 파일의 구문 실행 전에 account.sql, product.sql 실행하기
 
 -- Cart
-insert into cart (customer_id, product_id, cart_quantity)
-values (1, 1, 5),
-       (1, 2, 2);
+-- 비회원/회원용 장바구니
+INSERT INTO cart (cart_id, customer_id)
+VALUES (1, 1);
+
+-- CartItems
+INSERT INTO cart_items (cart_items_id, cart_id, product_id, cart_items_quantity)
+VALUES
+    (1, 1, 1, 1),
+    (2, 1, 2, 2);

--- a/src/main/resources/sql/data/order.sql
+++ b/src/main/resources/sql/data/order.sql
@@ -14,10 +14,6 @@ VALUES ('user@example.com', 'securepw', '홍길동');
 INSERT INTO delivery_fee (delivery_fee_amount, delivery_fee_free_amount, delivery_fee_date)
 VALUES (3000, 50000, CURDATE());
 
--- Payment
-INSERT INTO payment (payment_key, total_payment_amount, payment_requested_at, payment_approved_at, payment_method_id)
-VALUES ('PAY1234567890', 10000, NOW(), NOW(), 1);
-
 -- Order (order_code는 PK이므로 임의의 유일한 값)
 INSERT INTO `order` (
     order_code,
@@ -57,13 +53,17 @@ INSERT INTO `order` (
              1
          );
 
--- OrderDetail 적용 전에 proudct.sql 실행해서 데이터 넣어 놓기
+-- OrderDetail
 INSERT INTO order_detail (order_code, order_quantity, order_detail_per_price, product_id, order_state_id, wrapper_id, review_id)
 VALUES
     ('ORD20240506', 1, 1200000, 1, 1, null, NULL),
     ('ORD20240506', 2, 700000, 2, 2, null, NULL);
 
--- OrderReturn(OrderDetail이 있어야함)
+-- Payment
+INSERT INTO payment (payment_key, total_payment_amount, payment_requested_at, payment_approved_at, payment_method_id, order_code)
+VALUES ('PAY1234567890', 10000, NOW(), NOW(), 1, 'ORD20240506');
+
+-- OrderReturn
 INSERT INTO order_return (order_return_reason, return_category, order_detail_id)
 VALUES
     ('상품이 파손되어 도착했습니다.', 'CHANGE_MIND', 1),

--- a/src/main/resources/sql/ddl/ddl.sql
+++ b/src/main/resources/sql/ddl/ddl.sql
@@ -14,11 +14,18 @@ CREATE TABLE address
 
 CREATE TABLE cart
 (
-    cart_id       BIGINT AUTO_INCREMENT NOT NULL,
-    customer_id   BIGINT NOT NULL,
-    product_id    BIGINT NOT NULL,
-    cart_quantity INT    NOT NULL,
+    cart_id     BIGINT NOT NULL,
+    customer_id BIGINT NOT NULL,
     CONSTRAINT pk_cart PRIMARY KEY (cart_id)
+);
+
+CREATE TABLE cart_items
+(
+    cart_items_id       BIGINT NOT NULL,
+    cart_id             BIGINT NOT NULL,
+    product_id          BIGINT NOT NULL,
+    cart_items_quantity INT    NOT NULL,
+    CONSTRAINT pk_cartitems PRIMARY KEY (cart_items_id)
 );
 
 CREATE TABLE category
@@ -157,7 +164,6 @@ CREATE TABLE `order`
     order_created_at     datetime      NOT NULL,
     delivery_fee_id      BIGINT        NOT NULL,
     customer_id          BIGINT        NOT NULL,
-    payment_id           BIGINT        NOT NULL,
     CONSTRAINT pk_order PRIMARY KEY (order_code)
 );
 
@@ -197,6 +203,7 @@ CREATE TABLE payment
     payment_requested_at datetime     NOT NULL,
     payment_approved_at  datetime     NULL,
     payment_method_id    BIGINT       NOT NULL,
+    order_code           VARCHAR(255) NOT NULL,
     CONSTRAINT pk_payment PRIMARY KEY (payment_id)
 );
 
@@ -341,6 +348,9 @@ CREATE TABLE wrapper
     CONSTRAINT pk_wrapper PRIMARY KEY (wrapper_id)
 );
 
+ALTER TABLE cart
+    ADD CONSTRAINT uc_cart_customer UNIQUE (customer_id);
+
 ALTER TABLE member_coupon
     ADD CONSTRAINT uc_membercoupon_membercouponcode UNIQUE (member_coupon_code);
 
@@ -348,10 +358,16 @@ ALTER TABLE `order`
     ADD CONSTRAINT uc_order_delivery_fee UNIQUE (delivery_fee_id);
 
 ALTER TABLE `order`
-    ADD CONSTRAINT uc_order_payment UNIQUE (payment_id);
+    ADD CONSTRAINT uc_order_member_coupon UNIQUE (member_coupon_id);
+
+ALTER TABLE order_detail
+    ADD CONSTRAINT uc_orderdetail_product UNIQUE (product_id);
 
 ALTER TABLE order_detail
     ADD CONSTRAINT uc_orderdetail_review UNIQUE (review_id);
+
+ALTER TABLE payment
+    ADD CONSTRAINT uc_payment_order_code UNIQUE (order_code);
 
 ALTER TABLE payment
     ADD CONSTRAINT uc_payment_payment_method UNIQUE (payment_method_id);
@@ -360,13 +376,16 @@ ALTER TABLE product
     ADD CONSTRAINT uc_product_product_state UNIQUE (product_state_id);
 
 ALTER TABLE address
-    ADD CONSTRAINT FK_ADDRESS_ON_MEMBER_CUSTOMER FOREIGN KEY (customer_id) REFERENCES member (customer_id);
+    ADD CONSTRAINT FK_ADDRESS_ON_CUSTOMER FOREIGN KEY (customer_id) REFERENCES member (customer_id);
+
+ALTER TABLE cart_items
+    ADD CONSTRAINT FK_CARTITEMS_ON_CART FOREIGN KEY (cart_id) REFERENCES cart (cart_id);
+
+ALTER TABLE cart_items
+    ADD CONSTRAINT FK_CARTITEMS_ON_PRODUCT FOREIGN KEY (product_id) REFERENCES product (product_id);
 
 ALTER TABLE cart
     ADD CONSTRAINT FK_CART_ON_CUSTOMER FOREIGN KEY (customer_id) REFERENCES customer (customer_id);
-
-ALTER TABLE cart
-    ADD CONSTRAINT FK_CART_ON_PRODUCT FOREIGN KEY (product_id) REFERENCES product (product_id);
 
 ALTER TABLE category_coupon
     ADD CONSTRAINT FK_CATEGORYCOUPON_ON_CATEGORY FOREIGN KEY (category_id) REFERENCES category (category_id);
@@ -417,6 +436,9 @@ ALTER TABLE order_detail
     ADD CONSTRAINT FK_ORDERDETAIL_ON_ORDER_STATE FOREIGN KEY (order_state_id) REFERENCES order_state (order_state_id);
 
 ALTER TABLE order_detail
+    ADD CONSTRAINT FK_ORDERDETAIL_ON_PRODUCT FOREIGN KEY (product_id) REFERENCES product (product_id);
+
+ALTER TABLE order_detail
     ADD CONSTRAINT FK_ORDERDETAIL_ON_REVIEW FOREIGN KEY (review_id) REFERENCES review (review_id);
 
 ALTER TABLE order_detail
@@ -432,13 +454,16 @@ ALTER TABLE `order`
     ADD CONSTRAINT FK_ORDER_ON_DELIVERY_FEE FOREIGN KEY (delivery_fee_id) REFERENCES delivery_fee (delivery_fee_id);
 
 ALTER TABLE `order`
-    ADD CONSTRAINT FK_ORDER_ON_PAYMENT FOREIGN KEY (payment_id) REFERENCES payment (payment_id);
+    ADD CONSTRAINT FK_ORDER_ON_MEMBER_COUPON FOREIGN KEY (member_coupon_id) REFERENCES member_coupon (member_coupon_id);
+
+ALTER TABLE payment
+    ADD CONSTRAINT FK_PAYMENT_ON_ORDER_CODE FOREIGN KEY (order_code) REFERENCES `order` (order_code);
 
 ALTER TABLE payment
     ADD CONSTRAINT FK_PAYMENT_ON_PAYMENT_METHOD FOREIGN KEY (payment_method_id) REFERENCES payment_method (payment_method_id);
 
 ALTER TABLE point_history
-    ADD CONSTRAINT FK_POINTHISTORY_ON_MEMBER_CUSTOMER FOREIGN KEY (customer_id) REFERENCES member (customer_id);
+    ADD CONSTRAINT FK_POINTHISTORY_ON_CUSTOMER FOREIGN KEY (customer_id) REFERENCES member (customer_id);
 
 ALTER TABLE product_category
     ADD CONSTRAINT FK_PRODUCTCATEGORY_ON_CATEGORY FOREIGN KEY (category_id) REFERENCES category (category_id);


### PR DESCRIPTION
- Order 엔티티에 결제 상태 필드 추가 및 Payment 엔티티와의 관계 매핑을 Payment 엔티티가 주인으로 변경
- 장바구니를 cart와 cartitems로 분리
- 위 사항을 샘플 data와 ddl sql 적용