### PR TITLE
test(like & cart): 회원이 사용하는 컨트롤러 시그니처 메소드는 @Member 붙임, 항목 카운트 기능 문제 해결

### DIFF
--- a/src/main/java/com/nhnacademy/back/cart/controller/CartRestController.java
+++ b/src/main/java/com/nhnacademy/back/cart/controller/CartRestController.java
@@ -23,6 +23,7 @@ import com.nhnacademy.back.cart.domain.dto.request.RequestUpdateCartItemsDTO;
 import com.nhnacademy.back.cart.domain.dto.response.ResponseCartItemsForGuestDTO;
 import com.nhnacademy.back.cart.domain.dto.response.ResponseCartItemsForMemberDTO;
 import com.nhnacademy.back.cart.service.CartService;
+import com.nhnacademy.back.common.annotation.Member;
 import com.nhnacademy.back.common.exception.ValidationFailedException;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,16 +44,6 @@ public class CartRestController {
 
 	private final CartService cartService;
 
-
-	/** 게스트/회원 장바구니 공통 API **/
-	
-	@Operation(summary = "장바구니 상품 수 조회", description = "회원 ID로 장바구니에 담긴 상품 수를 조회합니다.")
-	@ApiResponse(responseCode = "200", description = "장바구니 상품 수 조회 성공", content = @Content(schema = @Schema(implementation = Integer.class)))
-	@GetMapping("/api/carts/counts")
-	public ResponseEntity<Integer> getCartItemsCounts(@Parameter(description = "회원 ID", required = true) @RequestParam String memberId) {
-		Integer result = cartService.getCartItemsCountsForMember(memberId);
-		return ResponseEntity.ok(result);
-	}
 
 	@Operation(summary = "비회원 장바구니 병합", description = "비회원의 장바구니를 회원 장바구니로 병합합니다.")
 	@ApiResponse(responseCode = "200", description = "장바구니 병합 성공", content = @Content(schema = @Schema(implementation = Integer.class)))
@@ -78,6 +69,7 @@ public class CartRestController {
 		@ApiResponse(responseCode = "201", description = "장바구니 상품 추가 성공", content = @Content(schema = @Schema(implementation = Integer.class))),
 		@ApiResponse(responseCode = "400", description = "유효성 검증 실패", content = @Content(schema = @Schema(implementation = ValidationFailedException.class)))
 	})
+	@Member
 	@PostMapping("/api/auth/members/carts/items")
 	public ResponseEntity<Integer> createCartItemForMember(@Parameter(description = "상품 추가 DTO", required = true) @Valid @RequestBody RequestAddCartItemsDTO requestDto,
 		                                                   @Parameter(hidden = true) BindingResult bindingResult) {
@@ -97,6 +89,7 @@ public class CartRestController {
 		@ApiResponse(responseCode = "200", description = "장바구니 수정 성공", content = @Content(schema = @Schema(implementation = Integer.class))),
 		@ApiResponse(responseCode = "400", description = "유효성 검증 실패", content = @Content(schema = @Schema(implementation = ValidationFailedException.class)))
 	})
+	@Member
 	@PutMapping("/api/auth/members/carts/items/{cartItemId}")
 	public ResponseEntity<Integer> updateCartItemForMember(@Parameter(description = "카트 항목 ID", required = true) @PathVariable long cartItemId,
 		                                                   @Parameter(description = "수정 요청 DTO", required = true) @Valid @RequestBody RequestUpdateCartItemsDTO requestDto,
@@ -114,6 +107,7 @@ public class CartRestController {
 
 	@Operation(summary = "회원 장바구니 상품 삭제", description = "회원 장바구니의 특정 상품을 삭제합니다.")
 	@ApiResponse(responseCode = "204", description = "장바구니 항목 삭제 성공")
+	@Member
 	@DeleteMapping("/api/auth/members/carts/items/{cartItemId}")
 	public ResponseEntity<Void> deleteCartItemForMember(@Parameter(description = "카트 항목 ID", required = true) @PathVariable long cartItemId) {
 		cartService.deleteCartItemForMember(cartItemId);
@@ -122,6 +116,7 @@ public class CartRestController {
 
 	@Operation(summary = "회원 장바구니 전체 삭제", description = "회원의 장바구니 전체를 삭제합니다.")
 	@ApiResponse(responseCode = "204", description = "장바구니 전체 삭제 성공")
+	@Member
 	@DeleteMapping("/api/auth/members/{memberId}/carts")
 	public ResponseEntity<Void> deleteCartForMember(@Parameter(description = "회원 ID", required = true) @PathVariable String memberId) {
 		cartService.deleteCartForMember(memberId);
@@ -130,10 +125,20 @@ public class CartRestController {
 
 	@Operation(summary = "회원 장바구니 조회", description = "회원의 장바구니 상품 목록을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "장바구니 목록 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseCartItemsForMemberDTO.class))))
+	@Member
 	@GetMapping("/api/auth/members/{memberId}/carts")
 	public ResponseEntity<List<ResponseCartItemsForMemberDTO>> getCartItemsByMember(@Parameter(description = "회원 ID", required = true) @PathVariable String memberId) {
 		List<ResponseCartItemsForMemberDTO> body = cartService.getCartItemsByMember(memberId);
 		return ResponseEntity.ok(body);
+	}
+
+	@Operation(summary = "회원 장바구니 상품 수 조회", description = "회원 ID로 장바구니에 담긴 상품 수를 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "장바구니 상품 수 조회 성공", content = @Content(schema = @Schema(implementation = Integer.class)))
+	@Member
+	@GetMapping("/api/carts/counts")
+	public ResponseEntity<Integer> getCartItemsCountsForMember(@Parameter(description = "회원 ID", required = true) @RequestParam String memberId) {
+		Integer result = cartService.getCartItemsCountsForMember(memberId);
+		return ResponseEntity.ok(result);
 	}
 
 

--- a/src/main/java/com/nhnacademy/back/cart/repository/CartItemsJpaRepository.java
+++ b/src/main/java/com/nhnacademy/back/cart/repository/CartItemsJpaRepository.java
@@ -16,7 +16,9 @@ public interface CartItemsJpaRepository extends JpaRepository<CartItems, Long> {
 	/// 특정 고객의 cartItems 목록 조회 메소드
 	List<CartItems> findByCart_Customer_CustomerId(long customerId);
 
-	/// 특정 장바구니 및 상품이 해당하는 장바구니 항목 조회
+	/// 특정 장바구니 및 상품이 해당하는 장바구니 항목 조회 메소드
 	Optional<CartItems> findByCartAndProduct(Cart cart, Product product);
 
+	/// 장바구니를 통해 항목 전체 개수 조회 메소드
+	int countByCart(Cart cart);
 }

--- a/src/main/java/com/nhnacademy/back/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/nhnacademy/back/cart/service/impl/CartServiceImpl.java
@@ -98,7 +98,7 @@ public class CartServiceImpl implements CartService {
 		// 장바구니 아이템 생성
 		cartItemsRepository.save(new CartItems(cart, findProduct, request.getQuantity()));
 
-		return cart.getCartItems().size();
+		return cartItemsRepository.countByCart(cart);
 	}
 
 	/**
@@ -231,8 +231,9 @@ public class CartServiceImpl implements CartService {
 			throw new NotFoundMemberException(NOT_FOUND_MEMBER);
 		}
 
-		Optional<Cart> findCart = cartRepository.findByCustomer_CustomerId(findMember.getCustomerId());
-		return findCart.map(cart -> cart.getCartItems().size()).orElse(0);
+		Cart findCart = cartRepository.findByCustomer_CustomerId(findMember.getCustomerId())
+			.orElseThrow(CartNotFoundException::new);
+		return cartItemsRepository.countByCart(findCart);
 	}
 
 
@@ -490,7 +491,7 @@ public class CartServiceImpl implements CartService {
 				}
 			}
 
-			return getCartItemsCountsForMember(findMember.getMemberId());
+			return cartItemsRepository.countByCart(findCart);
 		} else { // 비회원인 경우는 삭제만 처리하면 됨
 			Object o = redisTemplate.opsForValue().get(requestOrderCartDeleteDTO.getSessionId());
 			CartDTO cart = objectMapper.convertValue(o, CartDTO.class);

--- a/src/main/java/com/nhnacademy/back/product/like/controller/LikeRestController.java
+++ b/src/main/java/com/nhnacademy/back/product/like/controller/LikeRestController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nhnacademy.back.common.annotation.Member;
 import com.nhnacademy.back.common.exception.ValidationFailedException;
 import com.nhnacademy.back.product.like.domain.dto.request.RequestCreateLikeDTO;
 import com.nhnacademy.back.product.like.domain.dto.response.ResponseLikedProductDTO;
@@ -41,6 +42,7 @@ public class LikeRestController {
 		@ApiResponse(responseCode = "200", description = "좋아요 생성 성공"),
 		@ApiResponse(responseCode = "400", description = "유효성 검증 실패", content = @Content(schema = @Schema(implementation = ValidationFailedException.class)))
 	})
+	@Member
 	@PostMapping("/api/products/{productId}/likes")
 	public ResponseEntity<Void> createLike(@Parameter(description = "좋아요할 상품 ID", required = true) @PathVariable long productId,
 		                                   @Parameter(description = "좋아요 생성 요청 DTO", required = true) @Validated @RequestBody RequestCreateLikeDTO requestDto, 
@@ -57,6 +59,7 @@ public class LikeRestController {
 		@ApiResponse(responseCode = "200", description = "좋아요 삭제 성공"),
 		@ApiResponse(responseCode = "400", description = "유효성 검증 실패", content = @Content(schema = @Schema(implementation = ValidationFailedException.class)))
 	})
+	@Member
 	@DeleteMapping("/api/products/{productId}/likes")
 	public ResponseEntity<Void> deleteLike(@Parameter(description = "좋아요 취소할 상품 ID", required = true) @PathVariable long productId,
 		                                   @Parameter(description = "사용자 식별자", required = true) @RequestParam String memberId) {
@@ -66,6 +69,7 @@ public class LikeRestController {
 
 	@Operation(summary = "회원이 좋아요한 상품 목록 조회", description = "특정 회원이 좋아요한 상품들을 페이징하여 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "좋아요 상품 목록 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseLikedProductDTO.class))))
+	@Member
 	@GetMapping("/api/products/likes")
 	public ResponseEntity<Page<ResponseLikedProductDTO>> getLikedProductsByCustomer(@Parameter(description = "회원 아이디", required = true) @RequestParam String memberId,
 		                                                                            @Parameter(hidden = true) Pageable pageable) {
@@ -75,6 +79,7 @@ public class LikeRestController {
 
 	@Operation(summary = "상품 좋아요 수 조회", description = "특정 상품의 좋아요 수를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "좋아요 수 조회 성공", content = @Content(schema = @Schema(implementation = Long.class)))
+	@Member
 	@GetMapping("/api/products/{productId}/likes/counts")
 	public ResponseEntity<Long> getLikeCounts(@Parameter(description = "좋아요 수를 조회할 상품 ID", required = true) @PathVariable long productId) {
 		long body = likeService.getLikeCount(productId);

--- a/src/test/java/com/nhnacademy/back/cart/service/CartServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/back/cart/service/CartServiceImplTest.java
@@ -221,30 +221,34 @@ class CartServiceImplTest {
 		RequestDeleteCartOrderDTO dto = new RequestDeleteCartOrderDTO(memberId, null, productIds, quantities);
 
 		Member member = Member.builder()
-			.customerId(100L)
+			.customerId(1L)
 			.customer(customer)
 			.memberId(memberId)
 			.build();
 
-		Product product = Product.builder()
+		Product product1 = Product.builder()
 			.productId(1L)
+			.build();
+		Product product2 = Product.builder()
+			.productId(2L)
 			.build();
 
 		Cart cart = new Cart(customer);
-		CartItems item1 = new CartItems(cart, product, 5);
-		CartItems item2 = new CartItems(cart, product, 3);
+		CartItems item1 = new CartItems(cart, product1, 2);
+		CartItems item2 = new CartItems(cart, product2, 3);
 		cart.getCartItems().add(item1);
 		cart.getCartItems().add(item2);
 
 		when(memberRepository.getMemberByMemberId(memberId)).thenReturn(member);
 		when(cartRepository.findByCustomer_CustomerId(member.getCustomerId())).thenReturn(Optional.of(cart));
+		when(cartItemsRepository.countByCart(cart)).thenReturn(1);
 
 		// when
 		Integer result = cartService.deleteOrderCompleteCartItems(dto);
 
 		// then
-		assertEquals(1, result); // item1만 남음
-		verify(cartItemsRepository, times(1)).delete(item2);
+		assertEquals(1, result); // item2만 남음
+		verify(cartItemsRepository, times(1)).delete(item1);
 	}
 
 	@Test


### PR DESCRIPTION
- 회원이 사용하는 컨트롤러 시그니처 메소드는 @Member 붙임
- 장바구니 항목 카운트 기능에서 0개일 때 영속성 컨텍스트 기존 문제가 있어 쿼리메소드로 적용하여 해결